### PR TITLE
Better responsivness

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/html/chartjs.html
+++ b/src/main/resources/META-INF/resources/frontend/html/chartjs.html
@@ -2,7 +2,7 @@
 <script type="text/javascript" src="../js/jsonfn.min.js" ></script>
 <dom-module id="chart-js">
     <template>
-        <div class="chart-container">
+        <div class="chart-container" style="position: relative; height=100%; width=100%;">
             <canvas id="chart" on-click="handleClick"></canvas>
         </div>
     </template>


### PR DESCRIPTION
If you do it like this, the chart will always be as large as the parent component. Otherwise responsiveness only works for width but not for height.